### PR TITLE
Cli

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,35 @@
 # ov_wag
+
 Experimental - Open Vault Exhibits on Wagtail CMS
+
+## Usage
+
+### Initial setup
+
+Create an empty database file.
+
+```bash
+touch db.sqlite3
+```
+
+## Init script
+
+Several common functions can be executed with the `ov` init script (using Docker)
+
+For example, `./ov dev` will start the development server locally.
+
+_Note_ For most commands, additional args will be passed on to the parent command.
+
+- `dev` or `d`
+  - starts a local development server
+- `build` or `b`
+  - build (or rebuild) the docker image
+- `shell` or `s`
+  - starts a shell with all django variables loaded
+- `manage` or `m`
+  - run a `manage.py` command
+- `cmd` or `c`
+  - run a command directly on the container
+  - e.g.
+    - `./ov c bash`
+    - `./ov c python3 -c "print('OpenVault')"`

--- a/ov
+++ b/ov
@@ -16,12 +16,8 @@ elif [ $1 = "manage" -o $1 = "m" ]; then
   shift
   docker run -it -v $(pwd)/db.sqlite3:/app/db.sqlite3 ov python3 manage.py "$@"
 
-elif [ $1 = "container" -o $1 = "c" ]; then
+elif [ $1 = "cmd" -o $1 = "c" ]; then
   shift
   docker run -it ov "$@"
-
-elif [ $1 = "python" -o $1 = "py" ]; then
-  shift
-  docker run -it --entrypoint "/usr/local/bin/python3" ov "$@"
 
 fi

--- a/ov
+++ b/ov
@@ -10,11 +10,11 @@ elif [ $1 = "build" -o $1 = "b" ]; then
 
 elif [ $1 = "shell" -o $1 = "s" ]; then
   shift
-  docker run -it -v $(pwd)/db.sqlite3:/app/db.sqlite3 --entrypoint python3 ov manage.py shell "$@"
+  docker run -it -v $(pwd)/db.sqlite3:/app/db.sqlite3 ov python3 manage.py shell "$@"
   
 elif [ $1 = "manage" -o $1 = "m" ]; then
   shift
-  docker run -it -v $(pwd)/db.sqlite3:/app/db.sqlite3 --entrypoint python3 ov manage.py "$@"
+  docker run -it -v $(pwd)/db.sqlite3:/app/db.sqlite3 ov python3 manage.py "$@"
 
 elif [ $1 = "container" -o $1 = "c" ]; then
   shift

--- a/ov
+++ b/ov
@@ -1,9 +1,27 @@
 #!/bin/bash
 
 if [ $1 = "dev" -o $1 = "d" ]; then
-  docker run -itp 8000:8000 -v $(pwd)/db.sqlite3:/app/db.sqlite3 ov
+  shift
+  docker run -itp 8000:8000 -v $(pwd)/db.sqlite3:/app/db.sqlite3 ov "$@"
 
 elif [ $1 = "build" -o $1 = "b" ]; then
-  docker build -t ov .
+  shift
+  docker build -t ov . "$@"
+
+elif [ $1 = "shell" -o $1 = "s" ]; then
+  shift
+  docker run -it -v $(pwd)/db.sqlite3:/app/db.sqlite3 --entrypoint python3 ov manage.py shell "$@"
+  
+elif [ $1 = "manage" -o $1 = "m" ]; then
+  shift
+  docker run -it -v $(pwd)/db.sqlite3:/app/db.sqlite3 --entrypoint python3 ov manage.py "$@"
+
+elif [ $1 = "container" -o $1 = "c" ]; then
+  shift
+  docker run -it ov "$@"
+
+elif [ $1 = "python" -o $1 = "py" ]; then
+  shift
+  docker run -it --entrypoint "/usr/local/bin/python3" ov "$@"
 
 fi

--- a/ov
+++ b/ov
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+if [ $1 = "dev" -o $1 = "d" ]; then
+  docker run -itp 8000:8000 -v $(pwd)/db.sqlite3:/app/db.sqlite3 ov
+
+elif [ $1 = "build" -o $1 = "b" ]; then
+  docker build -t ov .
+
+fi


### PR DESCRIPTION
# CLI

Added basic command line init script (using docker)

## functions
- `dev` or `d`
  - starts a local development server
- `build` or `b`
  - build (or rebuild) the docker image
- `shell` or `s`
  - starts a shell with all django variables loaded
- `manage` or `m`
  - run a `manage.py` command
- `cmd` or `c`
  - run a command directly on the container
 
Included usage notes in readme.