### PR TITLE
Exhibit image tests

### DIFF
--- a/exhibit/models.py
+++ b/exhibit/models.py
@@ -8,14 +8,11 @@ from wagtail.api import APIField
 from pydantic import BaseModel
 
 
-class ImageMetaApiSchema(BaseModel):
-    download_url: str
-
-
 class ImageApiSchema(BaseModel):
-    id: int
-    title: str
-    meta: ImageMetaApiSchema
+    url: str
+    width: int
+    height: int
+    alt: str
 
 
 class ExhibitPageApiSchema(BaseModel):

--- a/exhibit/tests/factories.py
+++ b/exhibit/tests/factories.py
@@ -2,10 +2,11 @@ import factory
 import wagtail_factories
 from exhibit.models import ExhibitPage
 
+
 class ExhibitPageFactory(wagtail_factories.PageFactory):
 
-    cover_image = factory.SubFactory(
-        wagtail_factories.ImageChooserBlockFactory)
+    cover_image = factory.SubFactory(wagtail_factories.ImageChooserBlockFactory)
+    hero_image = factory.SubFactory(wagtail_factories.ImageChooserBlockFactory)
 
     class Meta:
         model = ExhibitPage

--- a/ov_wag/tests/test_api.py
+++ b/ov_wag/tests/test_api.py
@@ -42,7 +42,9 @@ class ApiTests(APITestCase):
         response = self.client.get(f'/api/v2/pages/{exhibit_page.id}/', format='json')
         json = response.json()
         ExhibitPageApiSchema(**json)
-        self.assertIsNotNone(json['cover_image']['meta']['download_url'])
+        self.assertIsNotNone(json['cover_image']['url'])
+        self.assertIsNotNone(json['hero_image']['url'])
+        self.assertIsNotNone(json['hero_thumb']['url'])
 
     def __home_page(self):
         return Site.objects.filter(is_default_site=True).first().root_page


### PR DESCRIPTION
# Exhibit Image API tests
Fixes API tests by aligning pydantic `ImageApiSchema` to API response
```python3
class ImageApiSchema(BaseModel):
    url: str
    width: int
    height: int
    alt: str
```

Tests are now [passing](https://github.com/WGBH-MLA/ov_wag/actions/runs/2505434109)!!! :tada: :fireworks: :champagne: 