### PR TITLE
34 api cover image

### DIFF
--- a/exhibit/api.py
+++ b/exhibit/api.py
@@ -7,8 +7,10 @@ class ExhibitAPIViewSet(BaseAPIViewSet):
 
     listing_default_fields = BaseAPIViewSet.listing_default_fields + [
         'title',
+        'body',
         'authors',
         'cover_image',
+        'cover_thumb',
         'hero_image',
         'hero_thumb',
     ]

--- a/exhibit/api.py
+++ b/exhibit/api.py
@@ -8,5 +8,7 @@ class ExhibitAPIViewSet(BaseAPIViewSet):
     listing_default_fields = BaseAPIViewSet.listing_default_fields + [
         'title',
         'authors',
+        'cover_image',
+        'hero_image',
         'hero_thumb',
     ]

--- a/exhibit/models.py
+++ b/exhibit/models.py
@@ -60,6 +60,10 @@ class ExhibitPage(Page):
             serializer=ImageRenditionField('fill-1600x500'),
         ),
         APIField(
+            'cover_thumb',
+            serializer=ImageRenditionField('fill-480x270', source='cover_image'),
+        ),
+        APIField(
             'hero_image',
             serializer=ImageRenditionField('fill-1920x1080'),
         ),

--- a/exhibit/models.py
+++ b/exhibit/models.py
@@ -20,6 +20,7 @@ class ExhibitPageApiSchema(BaseModel):
     title: str
     body: str
     cover_image: ImageApiSchema
+    cover_thumb: ImageApiSchema
     hero_image: ImageApiSchema
     hero_thumb: ImageApiSchema
 

--- a/ov_wag/tests/test_api.py
+++ b/ov_wag/tests/test_api.py
@@ -9,6 +9,10 @@ from exhibit.tests.factories import ExhibitPageFactory
 
 
 class ApiTests(APITestCase):
+    def assertValidSchema(self, item):
+        ExhibitPageApiSchema(**item)
+        return True
+
     def test_get_pages(self):
         """
         GET /api/v2/pages
@@ -41,7 +45,7 @@ class ApiTests(APITestCase):
         exhibit_page = ExhibitPageFactory.create(parent=self.__home_page())
         response = self.client.get(f'/api/v2/exhibit/{exhibit_page.id}/', format='json')
         json = response.json()
-        ExhibitPageApiSchema(**json)
+        self.assertValidSchema(json)
 
     def test_exhibit_api_schema_multiple(self):
         """
@@ -54,7 +58,7 @@ class ApiTests(APITestCase):
         json = response.json()
         print('json', json)
         for item in json['items']:
-            ExhibitPageApiSchema(**item)
+            self.assertValidSchema(item)
 
     def __home_page(self):
         return Site.objects.filter(is_default_site=True).first().root_page

--- a/ov_wag/tests/test_api.py
+++ b/ov_wag/tests/test_api.py
@@ -32,19 +32,29 @@ class ApiTests(APITestCase):
         response = self.client.get(f'/api/v2/pages/{exhibit_page.id}/', format='json')
         self.assertEqual(response.status_code, status.HTTP_200_OK)
 
-    def test_exhibit_cover_image(self):
+    def test_exhibit_api_schema_single(self):
         """
-        GET /api/v2/pages/{id} for Exhibit pages
+        GET /api/v2/exhibit/{id} for Exhibit pages
 
         Compare response against ExhibitSchema
         """
         exhibit_page = ExhibitPageFactory.create(parent=self.__home_page())
-        response = self.client.get(f'/api/v2/pages/{exhibit_page.id}/', format='json')
+        response = self.client.get(f'/api/v2/exhibit/{exhibit_page.id}/', format='json')
         json = response.json()
         ExhibitPageApiSchema(**json)
-        self.assertIsNotNone(json['cover_image']['url'])
-        self.assertIsNotNone(json['hero_image']['url'])
-        self.assertIsNotNone(json['hero_thumb']['url'])
+
+    def test_exhibit_api_schema_multiple(self):
+        """
+        GET /api/v2/exhibit for Exhibit pages
+
+        Compare response against ExhibitSchema
+        """
+        exhibit_page = ExhibitPageFactory.create(parent=self.__home_page())
+        response = self.client.get(f'/api/v2/exhibit/', format='json')
+        json = response.json()
+        print('json', json)
+        for item in json['items']:
+            ExhibitPageApiSchema(**item)
 
     def __home_page(self):
         return Site.objects.filter(is_default_site=True).first().root_page


### PR DESCRIPTION
# API: cover_image
Aligns `/exhibit` API schema to include:
- `cover_image`
- `cover_thumb`
- `hero_image`
- `hero_thumb`

## API Serializer
- Adds `cover_thumb` to API responses

## tests
- Cleans API tests
- `self.assertValidSchema`
  - custom assertion to DRY test process