### PR TITLE
Dockerfile production

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,6 +14,8 @@ RUN apt-get update --yes --quiet && apt-get install --yes --quiet --no-install-r
 COPY requirements.txt /
 RUN pip install -r /requirements.txt
 
+WORKDIR /app
+
 # Build the production image, with the application server
 FROM base as production
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -31,14 +31,6 @@ EXPOSE 80
 # Install the application server.
 RUN pip install "gunicorn>=20.1.0,<20.2.0"
 
-# Runtime command that executes when "docker run" is called, it does the
-# following:
-#   1. Migrate the database.
-#   2. Start the application server.
-# WARNING:
-#   Migrating database at the same time as starting the server IS NOT THE BEST
-#   PRACTICE. The database should be migrated manually or using the release
-#   phase facilities of your hosting platform. This is used only so the
-#   Wagtail instance can be started with a simple "docker run" command.
-# CMD set -xe; python manage.py migrate --noinput; gunicorn ov_wag.wsgi:application --reload
 COPY . .
+
+ENTRYPOINT /app/docker_entrypoints/deploy.sh

--- a/Dockerfile
+++ b/Dockerfile
@@ -39,3 +39,4 @@ RUN pip install "gunicorn>=20.1.0,<20.2.0"
 #   phase facilities of your hosting platform. This is used only so the
 #   Wagtail instance can be started with a simple "docker run" command.
 # CMD set -xe; python manage.py migrate --noinput; gunicorn ov_wag.wsgi:application --reload
+COPY . .

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,7 +8,6 @@ services:
     image: ov
     volumes:
       - ./:/app/
-    working_dir: /app
     entrypoint: /app/docker_entrypoints/dev.sh
     deploy:
       restart_policy:
@@ -23,7 +22,6 @@ services:
     image: ov-tests
     volumes:
       - ./:/app/
-    working_dir: /app
     entrypoint: /app/docker_entrypoints/test.sh
     environment:
       - OV_DB_ENGINE=django.db.backends.sqlite3

--- a/docker_entrypoints/deploy.sh
+++ b/docker_entrypoints/deploy.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+gunicorn ov_wag.wsgi:application --reload


### PR DESCRIPTION
# Dockerfile: Production

Extends `production` image
- `COPY` all files into container
- Move `WORKDIR` to `base` for use across all images
- Clean old configs, remove old comments

## `deploy.sh`
- Adds `ENTRYPOINT` for deploy
  - Runs server

Fixes broken config from [ov_deploy PR3](https://github.com/WGBH-MLA/ov_deploy/pull/3)
With [ov_deploy PR5](https://github.com/WGBH-MLA/ov_deploy/pull/5)
Progresses #40 