### PR TITLE
Draft release

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,23 @@
+changelog:
+  categories:
+    - title: Breaking Changes 🪅
+      labels:
+        - 'breaking :broken_heart:'
+
+    - title: New Features 🎉
+      labels:
+        - 'enhancement :heavy_plus_sign:'
+
+    - title: 'Bugfixes :bug:'
+      labels:
+        - 'bug :bug:'
+
+    - title: 'Maintenance :nut_and_bolt:'
+      labels:
+        - 'maintenance :wrench:'
+        - 'CI :test_tube:'
+        - 'CD :building_construction:'
+
+    - title: Other Changes
+      labels:
+        - '*'

--- a/.github/workflows/draft-release.yml
+++ b/.github/workflows/draft-release.yml
@@ -11,4 +11,4 @@ jobs:
         uses: actions/checkout@v3
 
       - name: 📦 Create draft release from milestone
-        uses: quaternionmedia/milestones@main
+        uses: WGBH-MLA/milestones@main

--- a/.github/workflows/draft-release.yml
+++ b/.github/workflows/draft-release.yml
@@ -1,0 +1,14 @@
+name: 📦 Release
+on:
+  milestone:
+    types: [closed]
+jobs:
+  release:
+    name: 📝 Draft Release
+    runs-on: ubuntu-latest
+    steps:
+      - name: 📰 Checkout
+        uses: actions/checkout@v3
+
+      - name: 📦 Create draft release from milestone
+        uses: quaternionmedia/milestones@main


### PR DESCRIPTION
# Draft release
Uses [WGBH-MLA/milestones](https://github.com/WGBH-MLA/milestones) (based on [Auto Release Milestone](https://github.com/marketplace/actions/auto-release-milestone)) Action to generate a draft release from each closed milestone.

Mirror of [ov_deploy PR#15](https://github.com/WGBH-MLA/ov_deploy/pull/15) and [ov-frontend PR#4](https://github.com/WGBH-MLA/ov-frontend/pull/4)